### PR TITLE
Listen to all refs on push events (and other small fixes)

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// switch to testdata dir to access dummy config.toml
+	os.Chdir("./testdata")
+
+	// set up verbose flags for testing
+	os.Args = append(os.Args, "-test.v")
+
+	go main()
+	os.Exit(m.Run())
+}
+
+func TestPushEventExplicit(t *testing.T) {
+	body, err := os.Open("./push_develop.json")
+	if err != nil {
+		t.Fatalf("Failed to open payload file. Error: %v", err)
+	}
+
+	client := http.Client{}
+	req, _ := http.NewRequest("POST", "http://localhost:9001", body)
+	req.Header.Add("X-GitHub-Event", "push")
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error posting to server. Error: %v", err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Errorf("Bad response from server. Response code: %v", res.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("Failed to read in response body. Error: %v", err)
+		t.FailNow()
+	}
+	res.Body.Close()
+
+	t.Logf("Data returned: %v", data)
+}
+
+func TestPushEventAll(t *testing.T) {
+	body, err := os.Open("./push_master.json")
+	if err != nil {
+		t.Fatalf("Failed to open payload file. Error: %v", err)
+	}
+
+	client := http.Client{}
+	req, _ := http.NewRequest("POST", "http://localhost:9001", body)
+	req.Header.Add("X-GitHub-Event", "push")
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error posting to server. Error: %v", err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Errorf("Bad response from server. Response code: %v", res.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("Failed to read in response body. Error: %v", err)
+		t.FailNow()
+	}
+	res.Body.Close()
+
+	t.Logf("Data returned: %v", data)
+}
+
+func TestPushEventBadRepo(t *testing.T) {
+	body, err := os.Open("./push_differentrepo.json")
+	if err != nil {
+		t.Fatalf("Failed to open payload file. Error: %v", err)
+	}
+
+	client := http.Client{}
+	req, _ := http.NewRequest("POST", "http://localhost:9001", body)
+	req.Header.Add("X-GitHub-Event", "push")
+
+	res, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Error posting to server. Error: %v", err)
+	}
+
+	if res.StatusCode != 200 {
+		t.Errorf("Bad response from server. Response code: %v", res.StatusCode)
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("Failed to read in response body. Error: %v", err)
+		t.FailNow()
+	}
+	res.Body.Close()
+
+	t.Logf("Data returned: %v", data)
+}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ const (
 var (
 	config            = tomlConfig{}                          // the program config
 	verbose           = false                                 // weither we should log the output of the command
+	verboseTunnel     = false                                 // weither we should log the output of the tunneling
 	gitHubSecretToken = os.Getenv("GITHUB_HOOK_SECRET_TOKEN") // the webhook secret token, used to verify signature
 )
 
@@ -169,10 +170,9 @@ func HeyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	verbosePtr := flag.Bool("v", false, "Whether we output stuff.")
-	verboseTunnelPtr := flag.Bool("vt", false, "Whether we output stuff regarding tunneling.")
+	flag.BoolVar(&verbose, "v", false, "Whether we output stuff.")
+	flag.BoolVar(&verboseTunnel, "vt", false, "Whether we output stuff regarding tunneling.")
 	flag.Parse()
-	verbose = *verbosePtr
 
 	// load the config.toml
 	config = loadConfig()
@@ -188,7 +188,7 @@ func main() {
 	readyToListen := false
 
 	if config.Tunnel {
-		if *verboseTunnelPtr {
+		if verboseTunnel {
 			gotunnelme.Debug = true
 		}
 		tunnel := gotunnelme.NewTunnel()

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -1,0 +1,16 @@
+# config file
+
+port = 9001
+addr = "127.0.0.1"
+
+[events."push:foo/bar:refs/heads/develop"]
+cmd = "echo"
+args = "Push!"
+
+[events."push:foo/bar:all"]
+cmd = "echo"
+args = "Push All!"
+
+[events."watch:foo/bar:refs/heads/develop"]
+cmd = "echo"
+args = "Watch!"

--- a/testdata/push_develop.json
+++ b/testdata/push_develop.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/develop",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/foo/bar/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/foo/bar/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "committer": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/foo/bar/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "committer": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "bar",
+    "full_name": "foo/bar",
+    "owner": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/foo/bar",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/foo/bar",
+    "forks_url": "https://api.github.com/repos/foo/bar/forks",
+    "keys_url": "https://api.github.com/repos/foo/bar/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/foo/bar/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/foo/bar/teams",
+    "hooks_url": "https://api.github.com/repos/foo/bar/hooks",
+    "issue_events_url": "https://api.github.com/repos/foo/bar/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/foo/bar/events",
+    "assignees_url": "https://api.github.com/repos/foo/bar/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/foo/bar/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/foo/bar/tags",
+    "blobs_url": "https://api.github.com/repos/foo/bar/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/foo/bar/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/foo/bar/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/foo/bar/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/foo/bar/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/foo/bar/languages",
+    "stargazers_url": "https://api.github.com/repos/foo/bar/stargazers",
+    "contributors_url": "https://api.github.com/repos/foo/bar/contributors",
+    "subscribers_url": "https://api.github.com/repos/foo/bar/subscribers",
+    "subscription_url": "https://api.github.com/repos/foo/bar/subscription",
+    "commits_url": "https://api.github.com/repos/foo/bar/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/foo/bar/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/foo/bar/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/foo/bar/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/foo/bar/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/foo/bar/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/foo/bar/merges",
+    "archive_url": "https://api.github.com/repos/foo/bar/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/foo/bar/downloads",
+    "issues_url": "https://api.github.com/repos/foo/bar/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/foo/bar/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/foo/bar/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/foo/bar/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/foo/bar/labels{/name}",
+    "releases_url": "https://api.github.com/repos/foo/bar/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/foo/bar.git",
+    "ssh_url": "git@github.com:foo/bar.git",
+    "clone_url": "https://github.com/foo/bar.git",
+    "svn_url": "https://github.com/foo/bar",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "foo",
+    "email": "foo@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "foo",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/foo",
+    "html_url": "https://github.com/foo",
+    "followers_url": "https://api.github.com/users/foo/followers",
+    "following_url": "https://api.github.com/users/foo/following{/other_user}",
+    "gists_url": "https://api.github.com/users/foo/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/foo/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/foo/subscriptions",
+    "organizations_url": "https://api.github.com/users/foo/orgs",
+    "repos_url": "https://api.github.com/users/foo/repos",
+    "events_url": "https://api.github.com/users/foo/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/foo/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/testdata/push_differentrepo.json
+++ b/testdata/push_differentrepo.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/master",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/foo/baz/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/foo/baz/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "committer": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/foo/baz/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "committer": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "bar",
+    "full_name": "foo/baz",
+    "owner": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/foo/baz",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/foo/baz",
+    "forks_url": "https://api.github.com/repos/foo/baz/forks",
+    "keys_url": "https://api.github.com/repos/foo/baz/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/foo/baz/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/foo/baz/teams",
+    "hooks_url": "https://api.github.com/repos/foo/baz/hooks",
+    "issue_events_url": "https://api.github.com/repos/foo/baz/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/foo/baz/events",
+    "assignees_url": "https://api.github.com/repos/foo/baz/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/foo/baz/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/foo/baz/tags",
+    "blobs_url": "https://api.github.com/repos/foo/baz/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/foo/baz/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/foo/baz/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/foo/baz/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/foo/baz/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/foo/baz/languages",
+    "stargazers_url": "https://api.github.com/repos/foo/baz/stargazers",
+    "contributors_url": "https://api.github.com/repos/foo/baz/contributors",
+    "subscribers_url": "https://api.github.com/repos/foo/baz/subscribers",
+    "subscription_url": "https://api.github.com/repos/foo/baz/subscription",
+    "commits_url": "https://api.github.com/repos/foo/baz/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/foo/baz/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/foo/baz/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/foo/baz/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/foo/baz/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/foo/baz/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/foo/baz/merges",
+    "archive_url": "https://api.github.com/repos/foo/baz/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/foo/baz/downloads",
+    "issues_url": "https://api.github.com/repos/foo/baz/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/foo/baz/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/foo/baz/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/foo/baz/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/foo/baz/labels{/name}",
+    "releases_url": "https://api.github.com/repos/foo/baz/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/foo/baz.git",
+    "ssh_url": "git@github.com:foo/baz.git",
+    "clone_url": "https://github.com/foo/baz.git",
+    "svn_url": "https://github.com/foo/baz",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "foo",
+    "email": "foo@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "foo",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/foo",
+    "html_url": "https://github.com/foo",
+    "followers_url": "https://api.github.com/users/foo/followers",
+    "following_url": "https://api.github.com/users/foo/following{/other_user}",
+    "gists_url": "https://api.github.com/users/foo/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/foo/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/foo/subscriptions",
+    "organizations_url": "https://api.github.com/users/foo/orgs",
+    "repos_url": "https://api.github.com/users/foo/repos",
+    "events_url": "https://api.github.com/users/foo/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/foo/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/testdata/push_master.json
+++ b/testdata/push_master.json
@@ -1,0 +1,161 @@
+{
+  "ref": "refs/heads/master",
+  "before": "9049f1265b7d61be4a8904a9a27120d2064dab3b",
+  "after": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "base_ref": null,
+  "compare": "https://github.com/foo/bar/compare/9049f1265b7d...0d1a26e67d8f",
+  "commits": [
+    {
+      "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "distinct": true,
+      "message": "Update README.md",
+      "timestamp": "2015-05-05T19:40:15-04:00",
+      "url": "https://github.com/foo/bar/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+      "author": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "committer": {
+        "name": "foo",
+        "email": "foo@users.noreply.github.com",
+        "username": "foo"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "distinct": true,
+    "message": "Update README.md",
+    "timestamp": "2015-05-05T19:40:15-04:00",
+    "url": "https://github.com/foo/bar/commit/0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c",
+    "author": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "committer": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com",
+      "username": "foo"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "README.md"
+    ]
+  },
+  "repository": {
+    "id": 35129377,
+    "name": "bar",
+    "full_name": "foo/bar",
+    "owner": {
+      "name": "foo",
+      "email": "foo@users.noreply.github.com"
+    },
+    "private": false,
+    "html_url": "https://github.com/foo/bar",
+    "description": "",
+    "fork": false,
+    "url": "https://github.com/foo/bar",
+    "forks_url": "https://api.github.com/repos/foo/bar/forks",
+    "keys_url": "https://api.github.com/repos/foo/bar/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/foo/bar/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/foo/bar/teams",
+    "hooks_url": "https://api.github.com/repos/foo/bar/hooks",
+    "issue_events_url": "https://api.github.com/repos/foo/bar/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/foo/bar/events",
+    "assignees_url": "https://api.github.com/repos/foo/bar/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/foo/bar/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/foo/bar/tags",
+    "blobs_url": "https://api.github.com/repos/foo/bar/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/foo/bar/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/foo/bar/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/foo/bar/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/foo/bar/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/foo/bar/languages",
+    "stargazers_url": "https://api.github.com/repos/foo/bar/stargazers",
+    "contributors_url": "https://api.github.com/repos/foo/bar/contributors",
+    "subscribers_url": "https://api.github.com/repos/foo/bar/subscribers",
+    "subscription_url": "https://api.github.com/repos/foo/bar/subscription",
+    "commits_url": "https://api.github.com/repos/foo/bar/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/foo/bar/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/foo/bar/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/foo/bar/issues/comments{/number}",
+    "contents_url": "https://api.github.com/repos/foo/bar/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/foo/bar/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/foo/bar/merges",
+    "archive_url": "https://api.github.com/repos/foo/bar/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/foo/bar/downloads",
+    "issues_url": "https://api.github.com/repos/foo/bar/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/foo/bar/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/foo/bar/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/foo/bar/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/foo/bar/labels{/name}",
+    "releases_url": "https://api.github.com/repos/foo/bar/releases{/id}",
+    "created_at": 1430869212,
+    "updated_at": "2015-05-05T23:40:12Z",
+    "pushed_at": 1430869217,
+    "git_url": "git://github.com/foo/bar.git",
+    "ssh_url": "git@github.com:foo/bar.git",
+    "clone_url": "https://github.com/foo/bar.git",
+    "svn_url": "https://github.com/foo/bar",
+    "homepage": null,
+    "size": 0,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": true,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 0,
+    "forks": 0,
+    "open_issues": 0,
+    "watchers": 0,
+    "default_branch": "master",
+    "stargazers": 0,
+    "master_branch": "master"
+  },
+  "pusher": {
+    "name": "foo",
+    "email": "foo@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "foo",
+    "id": 6752317,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6752317?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/foo",
+    "html_url": "https://github.com/foo",
+    "followers_url": "https://api.github.com/users/foo/followers",
+    "following_url": "https://api.github.com/users/foo/following{/other_user}",
+    "gists_url": "https://api.github.com/users/foo/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/foo/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/foo/subscriptions",
+    "organizations_url": "https://api.github.com/users/foo/orgs",
+    "repos_url": "https://api.github.com/users/foo/repos",
+    "events_url": "https://api.github.com/users/foo/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/foo/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
There's three bits to this PR, one of which is more important than the other two:

1) Ability to listen to any ref in a repository. I needed this because I wanted to use a webhook server to sync a remote repo any time any push happened.
2) In verbose mode, print the stderr as well as the stdout of the forked process
3) Small fix to flag code to simplify it and make the -vt flag more symmetric. This is stylistic, so I'd be fine if you don't want it.

As well I created a basic integration test suite to send some sample json through and test the new logic of handling all refs.
