### PR TITLE
Giving the server 10 seconds to start before integ tests run

### DIFF
--- a/integ_test.go
+++ b/integ_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -15,6 +18,24 @@ func TestMain(m *testing.M) {
 	os.Args = append(os.Args, "-test.v")
 
 	go main()
+
+	// make sure the server is up before running tests
+	tries := 10
+	for i := 0; i < tries; i++ {
+		if conn, err := net.Dial("tcp", "localhost:9001"); err == nil {
+			conn.Close()
+			fmt.Println("Server up!")
+			break
+		}
+		if i < tries-1 {
+			fmt.Printf("Server not up yet. Try %d\n", i)
+		} else {
+			fmt.Printf("Server not up after %d tries. Failing tests.\n", tries)
+			os.Exit(-1)
+		}
+		<-time.After(1 * time.Second)
+	}
+
 	os.Exit(m.Run())
 }
 

--- a/integ_test.go
+++ b/integ_test.go
@@ -24,7 +24,8 @@ func TestMain(m *testing.M) {
 	for i := 0; i < tries; i++ {
 		if conn, err := net.Dial("tcp", "localhost:9001"); err == nil {
 			conn.Close()
-			fmt.Println("Server up!")
+			fmt.Println("Server up! Waiting another second.")
+			<-time.After(1 * time.Second)
 			break
 		}
 		if i < tries-1 {


### PR DESCRIPTION
The Ci server build failed because the server did not start up before the tests began. This adds logic to try once a second for 10 seconds to connect to the server to ensure it is up before the tests run.
