### PR TITLE
config file flag and systemd unit file

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,14 @@ type event struct {
 // loadConfig loads the config.toml file into a tomlConfig struct
 func loadConfig() tomlConfig {
 	var config tomlConfig
+	if configFile != "" {
+		if _, err := toml.DecodeFile(configFile, &config); err != nil {
+			return config
+		} else {
+			fmt.Println(err)
+			fmt.Println("failed loading config, going to fallback")
+		}
+	}
 	if _, err := toml.DecodeFile("./config.toml", &config); err != nil {
 		fmt.Println(err)
 		panic("nope")

--- a/harpoon@.service
+++ b/harpoon@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Harpoon server for user %i
+After=network.target
+AssertFileNotEmpty=/usr/local/bin/harpoon
+AssertFileIsExecutable=/usr/local/bin/harpoon
+
+[Service]
+User=%i
+Type=simple
+ExecStart=/usr/local/bin/harpoon /home/%i/harpoon.toml
+Nice=5
+
+[Install]
+WantedBy=multi-user.target

--- a/main.go
+++ b/main.go
@@ -27,9 +27,10 @@ const (
 )
 
 var (
-	config            = tomlConfig{}                          // the program config
-	verbose           = false                                 // weither we should log the output of the command
-	verboseTunnel     = false                                 // weither we should log the output of the tunneling
+	config            = tomlConfig{} // the program config
+	verbose           = false        // weither we should log the output of the command
+	verboseTunnel     = false        // weither we should log the output of the tunneling
+	configFile        = ""
 	gitHubSecretToken = os.Getenv("GITHUB_HOOK_SECRET_TOKEN") // the webhook secret token, used to verify signature
 )
 
@@ -172,6 +173,7 @@ func HeyHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	flag.BoolVar(&verbose, "v", false, "Whether we output stuff.")
 	flag.BoolVar(&verboseTunnel, "vt", false, "Whether we output stuff regarding tunneling.")
+	flag.StringVar(&configFile, "c", "", "config file to load other than ./config.toml")
 	flag.Parse()
 
 	// load the config.toml


### PR DESCRIPTION
I figure some people might want to use this in a multi-tenant environment - multiple users on the same webhost wanting the same script.

With that in mind, I modified the binary, adding a config file flag (`-c`):
```
⇒  harpoon -help
Usage of harpoon:
  -c string
    	config file to load other than ./config.toml
  -v	Whether we output stuff.
  -vt
    	Whether we output stuff regarding tunneling.
```

I also added a systemd template file - it's the reality I'm saddled with.

Now, by copying the binary into place, and copying the unit file into `/etc/systemd/system/` or w/e, then creating a config file in each user's home directory, anyone should be able to run a harpoon instance per user.

I figured this would be fairly helpful, for some use cases.